### PR TITLE
Remote config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,38 @@ ghc:
     - 7.6
     - 7.8
 env:
-    - OPTPARSE_APPLICATIVE_BOUND=0.11
-    - OPTPARSE_APPLICATIVE_BOUND=10
+    - OPTPARSE_APPLICATIVE_BOUND=0.11 REMOTE_CONFIGS=-f-remote-configs CABALBOUND=1.22 CABALVER=1.20
+    - OPTPARSE_APPLICATIVE_BOUND=10 REMOTE_CONFIGS=-fremote-configs CABALBOUND=1.22 CABALVER=1.20
+
+    - OPTPARSE_APPLICATIVE_BOUND=0.11 REMOTE_CONFIGS=-f-remote-configs CABALBOUND=2 CABALVER=1.22
+    - OPTPARSE_APPLICATIVE_BOUND=10 REMOTE_CONFIGS=-fremote-configs CABALBOUND=2 CABALVER=1.22
+
+matrix:
+    exclude:
+        - env: OPTPARSE_APPLICATIVE_BOUND=0.11 REMOTE_CONFIGS=-f-remote-configs CABALBOUND=2 CABALVER=1.22
+          ghc: 7.6
+        - env: OPTPARSE_APPLICATIVE_BOUND=10 REMOTE_CONFIGS=-fremote-configs CABALBOUND=2 CABALVER=1.22
+          ghc: 7.6
+
+before_install:
+    # - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
+    # - travis_retry sudo apt-get update
+    # - travis_retry sudo apt-get install cabal-install-$CABALVER
+    # - export PATH=/opt/cabal/$CABALVER/bin:$PATH
+    - travis_retry cabal update
+    - mkdir $HOME/bin
+    - cabal install cabal-install --bindir=$HOME/bin --constraint="Cabal<$CABALBOUND"
+    - export PATH=$HOME/bin:$PATH
 
 install:
-    - cabal install --only-dependencies --enable-tests --constraint="optparse-applicative<$OPTPARSE_APPLICATIVE_BOUND"
+    - cabal --version
+    - travis_retry cabal update
+    - cabal install --only-dependencies --enable-tests --constraint="optparse-applicative<$OPTPARSE_APPLICATIVE_BOUND" --constraint="Cabal<$CABALBOUND" $REMOTE_CONFIGS
+
+script:
+    - cabal clean
+    - cabal configure --enable-tests --constraint="optparse-applicative<$OPTPARSE_APPLICATIVE_BOUND" --constraint="Cabal<$CABALBOUND" $REMOTE_CONFIGS
+    - cabal build
+    - cabal test
+    - cabal sdist
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ provided:
 4.  an options parser that yields a function that takes a value and updates
     that value with the values provided as command line options.
 
+Optionally, a function for validating the configuration value may be
+provided.
+
 The package provides operators and functions that make the implmentation of
 these requisites easy for the common case that the configuration is encoded
 mainly through nested records.
@@ -58,12 +61,21 @@ In addition to the user defined command line options the following
 options are recognized by the application:
 
 `--config-file, -c`
-:    parses the given file as a (partial) configuration in YAML format.
+:   parses the given file as a (partial) configuration in YAML format.
+    The file location can be provided either as a local filesystem path
+    or as a remote HTTP or HTTPS URL. In addition a list of static
+    configuration file locations can be defined in the code.
+
+    If this option is provided more than a single time the configuration
+    files are loaded in the order as the respective options appear
+    on the command line, where settings that are loaded later have
+    precedence over earlier settings. Files from static locations are
+    loaded before files that are specified on the command line.
 
 `print-config, -p`
-:    configures the application and prints the configuration in YAML format
-     to standard out and exits. The printed configuration is exactly the
-     configuration that otherwise would be used to run the application.
+:   configures the application and prints the configuration in YAML format
+    to standard out and exits. The printed configuration is exactly the
+    configuration that otherwise would be used to run the application.
 
 `--help, -h`
 :   prints a help message and exits.
@@ -117,8 +129,9 @@ pwd :: Functor f => (String -> f String) -> Auth -> f Auth
 pwd f s = (\p -> s { _pwd = p }) <$> f (_pwd s)
 ~~~
 
-(Note, that the module `Configuration.Utils` defines its own `Lens'` type synonym.
-If you import `Control.Lens` you should hide `Lens'` from either module.)
+(Note, that the module `Configuration.Utils` defines its own type synonyms for
+lenses. If you import `Control.Lens` you should hide `Lens` and `Lens'` from
+either module.)
 
 We must provide a default value. If there is no reasonable default the
 respective value could, for instance, be wrapped into `Maybe`. Here we
@@ -263,12 +276,11 @@ is non-determinism in the choice of the constructor, too.
 
 An update function for a product type can be defined pointwise as a mapping from
 constructor parameters to values. An update for a sum type must take the
-constructor context into account. In terms of the lens library this is reflected
-by using `Lens`es for product types and `Prism`s for sum types. Therefore a
-configuration that defines an update function for a sum types must also specify
-the constructor context. Moreover, when applied to a given default value the
-function may not be applicable at all if the default value uses a different
-constructor context than what the update assumes.
+constructor context into account. Therefore a configuration that defines an
+update function for a sum types must also specify the constructor context.
+Moreover, when applied to a given default value the function may not be
+applicable at all if the default value uses a different constructor context
+than what the update assumes.
 
 For the future we plan to provide a general solution for configurations of sum
 types which would be based on the possibility to define default values for more
@@ -545,14 +557,12 @@ are planned.
 *   Provide operators (or at least examples) for more scenarios
     (like required options)
 
-*   Nicer errors messages if parsing fails.
+*   Nicer error messages if parsing fails.
 
 *   Suport JSON encoded configuration files.
 
 *   Support mode where JSON/YAML parsing fails when unexpected
     properties are encountered.
-
-*   Loading of configurations from URLs.
 
 *   Include default values in help message.
 

--- a/configuration-tools.cabal
+++ b/configuration-tools.cabal
@@ -102,10 +102,13 @@ Test-Suite url-example-test
     build-depends:
         base >= 4.6 && < 5.0,
         base-unicode-symbols >= 0.2.2.4,
+        bytestring >= 0.10,
+        Cabal >= 1.20,
         configuration-tools,
         errors >= 1.4.3,
         mtl >= 2.2,
-        text >= 1.0
+        text >= 1.0,
+        yaml >= 0.8.8.3
 
     ghc-options: -Wall
     cpp-options: -DMain=Example

--- a/configuration-tools.cabal
+++ b/configuration-tools.cabal
@@ -75,6 +75,7 @@ Library
     build-depends:
         Cabal >= 1.20,
         aeson >= 0.7.0.6,
+        ansi-wl-pprint >= 0.6,
         attoparsec >= 0.11.3.4,
         base >= 4.6 && < 5.0,
         base-unicode-symbols >= 0.2.2.4,

--- a/configuration-tools.cabal
+++ b/configuration-tools.cabal
@@ -123,6 +123,16 @@ Test-Suite url-example-test
         text >= 1.0,
         yaml >= 0.8.8.3
 
+    if flag(remote-configs)
+        build-depends:
+            enclosed-exceptions >= 1.0,
+            http-types >= 0.8,
+            monad-control >= 1.0,
+            wai >= 3.0,
+            warp >= 3.0
+
+        cpp-options: -DREMOTE_CONFIGS
+
     ghc-options: -Wall
 
 Test-Suite trivial

--- a/configuration-tools.cabal
+++ b/configuration-tools.cabal
@@ -56,6 +56,11 @@ source-repository this
     location: https://github.com/alephcloud/hs-configuration-tools.git
     tag: 0.2.8
 
+flag remote-configs
+    Description: enable loading of configuration files from HTTP URLs
+    Default: True
+    Manual: True
+
 Library
     hs-source-dirs: src
     default-language: Haskell2010
@@ -87,6 +92,14 @@ Library
         unordered-containers >= 0.2.4.0,
         yaml >= 0.8.8.3,
         profunctors >= 4.0.4
+
+    if flag(remote-configs)
+        build-depends:
+            enclosed-exceptions >= 1.0,
+            http-conduit >= 2.1,
+            monad-control >= 1.0
+
+        cpp-options: -DREMOTE_CONFIGS
 
     ghc-options: -Wall
 

--- a/configuration-tools.cabal
+++ b/configuration-tools.cabal
@@ -124,7 +124,6 @@ Test-Suite url-example-test
         yaml >= 0.8.8.3
 
     ghc-options: -Wall
-    cpp-options: -DMain=Example
 
 Test-Suite trivial
     type: exitcode-stdio-1.0

--- a/examples/Example.hs
+++ b/examples/Example.hs
@@ -8,7 +8,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE FlexibleInstances #-}
 
-module Main
+module Example
 (
 -- * Authentication
   Auth(..)

--- a/src/Configuration/Utils.hs
+++ b/src/Configuration/Utils.hs
@@ -123,6 +123,7 @@ module Configuration.Utils
 ) where
 
 import Configuration.Utils.Internal
+import Configuration.Utils.Validation
 
 import Control.Error (fmapL)
 import Control.Monad.Except hiding (mapM_)
@@ -533,11 +534,6 @@ eitherReadP label p s =
 
 -- -------------------------------------------------------------------------- --
 -- Main Configuration
-
--- | A validation function. The type in the 'MonadWriter' is excpected to
--- be a 'Foldable' structure for collecting warnings.
---
-type ConfigValidation α λ = (MonadIO μ, Functor μ, Applicative μ, MonadError T.Text μ, MonadWriter (λ T.Text) μ) ⇒ α → μ ()
 
 -- | A newtype wrapper around a validation function. The only purpose of
 -- this type is to avoid @ImpredicativeTypes@ when storing the function

--- a/src/Configuration/Utils/Validation.hs
+++ b/src/Configuration/Utils/Validation.hs
@@ -15,9 +15,10 @@
 -- Utilities for validating configuration values
 --
 module Configuration.Utils.Validation
-(
+( ConfigValidation
+
 -- * Networking
-  validateHttpOrHttpsUrl
+, validateHttpOrHttpsUrl
 , validateHttpUrl
 , validateHttpsUrl
 , validateUri
@@ -63,12 +64,13 @@ module Configuration.Utils.Validation
 , validateRange
 ) where
 
-import Configuration.Utils
 import Configuration.Utils.Internal
 
+import Control.Applicative
 import Control.Monad.Error.Class
 import Control.Monad
 import Control.Monad.IO.Class
+import Control.Monad.Writer.Class
 
 import qualified Data.Foldable as F
 import Data.Monoid
@@ -80,6 +82,11 @@ import Network.URI
 import Prelude.Unicode
 
 import System.Directory
+
+-- | A validation function. The type in the 'MonadWriter' is excpected to
+-- be a 'Foldable' structure for collecting warnings.
+--
+type ConfigValidation α λ = (MonadIO μ, Functor μ, Applicative μ, MonadError T.Text μ, MonadWriter (λ T.Text) μ) ⇒ α → μ ()
 
 -- -------------------------------------------------------------------------- --
 -- Networking

--- a/test/TestExample.hs
+++ b/test/TestExample.hs
@@ -23,103 +23,271 @@ import Configuration.Utils.Internal
 import Control.Exception
 import Control.Monad
 
+import qualified Data.ByteString.Char8 as B8
 import Data.IORef
 import qualified Data.List as L
 import Data.Monoid.Unicode
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
+import qualified Data.Yaml as Yaml
+
+import Distribution.Simple.Utils (withTempFile)
 
 import Example hiding (main)
 
 import Prelude.Unicode
 
 import System.Environment
+import System.IO
 
 import PkgInfo_url_example_test
+
+-- -------------------------------------------------------------------------- --
+-- Poor man's debugging
+
+enableDebug ∷ Bool
+enableDebug = True
+
+debug
+    ∷ Monad m
+    ⇒ m ()
+    → m ()
+debug a
+    | enableDebug = a
+    | otherwise = return ()
 
 -- -------------------------------------------------------------------------- --
 -- main
 
 main ∷ IO ()
-main = do
-    (successes, failures) ← L.partition id <$> (sequence
-        [ run "test0" False []
+main =
+    withTempFile "." "tmp_TestExample.yml" $ \tmpPath0 tmpHandle0 →
+    withTempFile "." "tmp_TestExample.yml" $ \tmpPath1 tmpHandle1 → do
 
-        , run "test1" True [t0]
-        , run "test2" True [t1]
-        , run "test3" True [t2]
-        , run "test4" False [t3]
-        , run "test5" False [t4]
+        B8.hPutStrLn tmpHandle0 ∘ Yaml.encode $ fileConfig0
+        hClose tmpHandle0
 
-        , run "test6" False [t0, t1]
-        , run "test7" True [t0, t2]
-        , run "test8" True [t0, t3]
-        , run "test9" True [t0, t4]
-        , run "test10" True [t1, t2]
-        , run "test11" True [t1, t3]
-        , run "test12" True [t1, t4]
-        , run "test13" True [t2, t3]
-        , run "test14" True [t2, t4]
-        , run "test15" False [t3, t4]
+        T.hPutStrLn tmpHandle1 fileConfig1Part
+        hClose tmpHandle1
 
-        , run "test16" False [t0, t1, t2]
-        , run "test17" False [t0, t1, t3]
-        , run "test18" False [t0, t1, t4]
-        , run "test19" True [t0, t2, t3]
-        , run "test20" True [t0, t2, t4]
-        , run "test21" True [t0, t3, t4]
-        , run "test22" True [t1, t2, t3]
-        , run "test23" True [t1, t2, t4]
-        , run "test24" True [t1, t3, t4]
-        , run "test25" True [t2, t3, t4]
+        (successes, failures) ← L.partition id <$> sequence
+            × tests0
+            ⊕ tests1 [T.pack tmpPath0, T.pack tmpPath1]
+            ⊕ tests2 (T.pack tmpPath0) (T.pack tmpPath1)
 
-        , run "test26" False [t0, t1, t2, t3]
-        , run "test27" False [t0, t1, t2, t4]
-        , run "test28" False [t0, t1, t3, t4]
+        T.putStrLn $ "success: " ⊕ sshow (length successes)
+        T.putStrLn $ "failures: " ⊕ sshow (length failures)
+        unless (length failures ≡ 0) $ do
+            debug $ do
+                T.readFile tmpPath0 >>= T.putStrLn
+                T.readFile tmpPath1 >>= T.putStrLn
+            error "test suite failed"
+  where
+
+    -- tests with configuration files
+
+    runf files = runTest $ mainInfoConfigFile files
+
+    fileConfig0 = defaultHttpURL
+        { _domain = "f0_localhost"
+        , _path = "f0_path"
+        , _auth = defaultAuth
+            { _user = "f0_user"
+            , _pwd = "f0_pwd"
+            }
+        }
+
+    fileConfig1 = defaultHttpURL
+        { _domain = "f1_localhost"
+        , _path = "f1_path"
+        , _auth = defaultAuth
+            { _user = "f1_user"
+            , _pwd = "f1_pwd"
+            }
+        }
+
+    -- We only write a partial configuration file...
+    fileConfig1Part = T.unlines
+        [ "domain: " ⊕ T.pack (view domain fileConfig1)
+        , "auth:"
+        , "    user: " ⊕ T.pack (view (auth ∘ user) fileConfig1)
+        ]
+
+    tests2 file0 file1 =
+        -- first c0 then c1
+        [ runf [file0] "test-2-0" True [x1 (f1 c1), f2 c0, f3 c1, f4 c0]
+        , runf [file0] "test-2-1" False [x1 (f1 c0)]
+        , runf [file0] "test-2-2" False [x1 d1]
+        , runf [file0] "test-2-3" False [x1 (f3 c0)]
+        , runf [file0] "test-2-4" False [x1 d4]
+
+        -- c1 then c0
+        , runf [file1] "test-2-5" True [x0 (f1 c0), f2 c0, f3 c0, f4 c0]
+        , runf [file1] "test-2-6" False [x0 (f1 c1)]
+        , runf [file1] "test-2-7" False [x0 (f2 c1)]
+        , runf [file1] "test-2-8" False [x0 (f3 c1)]
+        , runf [file1] "test-2-9" False [x0 (f4 c1)]
+        ]
+      where
+        c0 = fileConfig0
+        c1 = fileConfig1
+        x0 (ConfAssertion args l v) = ConfAssertion (("--config-file=" ⊕ T.unpack file0):args) l v
+        x1 (ConfAssertion args l v) = ConfAssertion (("--config-file=" ⊕ T.unpack file1):args) l v
+
+    tests1 files =
+        -- first c0 then c1
+        [ runf files "test-1-0" True [f1 c1, f2 c0, f3 c1, f4 c0]
+        , runf files "test-1-1" False [f1 c0]
+        , runf files "test-1-2" False [d1]
+        , runf files "test-1-3" False [f3 c0]
+        , runf files "test-1-4" False [d4]
+
+        -- c1 then c0
+        , runf selif "test-1-5" True [f1 c0, f2 c0, f3 c0, f4 c0]
+        , runf selif "test-1-6" False [f1 c1]
+        , runf selif "test-1-7" False [f2 c1]
+        , runf selif "test-1-8" False [f3 c1]
+        , runf selif "test-1-9" False [f4 c1]
+        ]
+      where
+        c0 = fileConfig0
+        c1 = fileConfig1
+        selif = reverse files
+
+    -- simple Tests
+
+    run = runTest mainInfo
+    tests0 =
+        [ run "test0" False [d1, d2, d3, d4]
+
+        , run "test1" True [t0, d2, d3, d4]
+        , run "test2" True [t1, d2, d3, d4]
+        , run "test3" True [d1, t2, d3, d4]
+        , run "test4" False [d1, d2, t3, d4]
+        , run "test5" False [d1, d2, d3, t4]
+
+        , run "test6" False [t0, t1, d2, d3, d4]
+        , run "test7" True [t0, t2, d3, d4]
+        , run "test8" True [t0, d2, t3, d4]
+        , run "test9" True [t0, d2, d3, t4]
+        , run "test10" True [t1, t2, d3, d4]
+        , run "test11" True [t1, d2, t3, d4]
+        , run "test12" True [t1, d2, d3, t4]
+        , run "test13" True [d1, t2, t3, d4]
+        , run "test14" True [d1, t2, d3, t4]
+        , run "test15" False [d1, d2, t3, t4]
+
+        , run "test16" False [t0, t1, t2, d3, d4]
+        , run "test17" False [t0, t1, t3, d4]
+        , run "test18" False [t0, t1, d3, t4]
+        , run "test19" True [t0, t2, t3, d4]
+        , run "test20" True [t0, t2, d3, t4]
+        , run "test21" True [t0, d2, t3, t4]
+        , run "test22" True [t1, t2, t3, d4]
+        , run "test23" True [t1, t2, d3, t4]
+        , run "test24" True [t1, d2, t3, t4]
+        , run "test25" True [d1, t2, t3, t4]
+
+        , run "test26" False [t0, t1, t2, t3, d4]
+        , run "test27" False [t0, t1, t2, d3, t4]
+        , run "test28" False [t0, t1, d2, t3, t4]
         , run "test29" True [t0, t2, t3, t4]
         , run "test30" True [t1, t2, t3, t4]
 
         , run "test31" False [t0, t1, t2, t3, t4]
-        ] ∷ IO [Bool])
-
-    T.putStrLn $ "success: " ⊕ sshow (length successes)
-    T.putStrLn $ "failures: " ⊕ sshow (length failures)
-    unless (length failures ≡ 0) $ error "test suite failed"
-  where
-    run = runTest mainInfo
+        ]
 
 mainInfo ∷ ProgramInfoValidate HttpURL []
 mainInfo = programInfoValidate "HTTP URL" pHttpURL defaultHttpURL validateHttpURL
 
+mainInfoConfigFile
+    ∷ [T.Text]
+    → ProgramInfoValidate HttpURL []
+mainInfoConfigFile files = set piConfigurationFiles files mainInfo
+
 -- -------------------------------------------------------------------------- --
 -- Test Vectors
 
+-- | Specify a assertion about the parsed configuration
+--
+-- The parameters are
+--
+-- 1. list of command line arguments,
+-- 2. lens for the configuration value
+-- 3. the expected value
+--
 data ConfAssertion β = ∀ α . Eq α ⇒ ConfAssertion [String] (Lens' β α) α
 
+-- assert values from given configuration
+
+f1 ∷ HttpURL → ConfAssertion HttpURL
+f1 conf = ConfAssertion [] domain (view domain conf)
+
+f2 ∷ HttpURL → ConfAssertion HttpURL
+f2 conf = ConfAssertion [] path (view path conf)
+
+f3 ∷ HttpURL → ConfAssertion HttpURL
+f3 conf = ConfAssertion [] (auth ∘ user) (view (auth ∘ user) conf)
+
+f4 ∷ HttpURL → ConfAssertion HttpURL
+f4 conf = ConfAssertion [] (auth ∘ pwd) (view (auth ∘ pwd) conf)
+
+-- assert default values
+
+d1 ∷ ConfAssertion HttpURL
+d1 = f1 defaultHttpURL
+
+d2 ∷ ConfAssertion HttpURL
+d2 = f2 defaultHttpURL
+
+d3 ∷ ConfAssertion HttpURL
+d3 = f3 defaultHttpURL
+
+d4 ∷ ConfAssertion HttpURL
+d4 = f4 defaultHttpURL
+
+-- assert values from command line
+
+-- t0 and t1 are the same option
 t0 ∷ ConfAssertion HttpURL
-t0 = ConfAssertion ["--domain=localhost"] domain "localhost"
+t0 = ConfAssertion ["--domain=c_localhost"] domain "c_localhost"
 
 t1 ∷ ConfAssertion HttpURL
-t1 = ConfAssertion ["-d", "localhost"] domain "localhost"
+t1 = ConfAssertion ["-d", "c_localhost"] domain "c_localhost"
 
 t2 ∷ ConfAssertion HttpURL
-t2 = ConfAssertion ["--path=abc"] path "abc"
+t2 = ConfAssertion ["--path=c_abc"] path "c_abc"
 
 t3 ∷ ConfAssertion HttpURL
-t3 = ConfAssertion ["--user=u"] (auth ∘ user) "u"
+t3 = ConfAssertion ["--user=c_u"] (auth ∘ user) "c_u"
 
 t4 ∷ ConfAssertion HttpURL
-t4 = ConfAssertion ["--pwd=pwd"] (auth ∘ pwd) "pwd"
+t4 = ConfAssertion ["--pwd=c_pwd"] (auth ∘ pwd) "c_pwd"
 
 -- -------------------------------------------------------------------------- --
 -- Test execution
 
+-- Check the given list of assertions for the given configuration value
+--
 check
     ∷ α
     → [ConfAssertion α]
-    → Bool
-check conf = all (\(ConfAssertion _ l v) → view l conf ≡ v)
+    → IO Bool
+check conf assertions =
+    foldM (\a (b,n) → (&& a) <$> go b n) True $ zip assertions [0 ∷ Int ..]
+  where
+    go (ConfAssertion _ l v) n =
+        if view l conf ≡ v
+          then do
+            debug ∘ T.putStrLn $ "DEBUG: assertion " ⊕ sshow n ⊕ " succeeded"
+            return True
+          else do
+            debug ∘ T.putStrLn $ "DEBUG: assertion " ⊕ sshow n ⊕ " failed"
+            return False
 
+-- | Run a test with an expected outcome ('True' or 'False')
+-- for a given that of assertions.
+--
 runTest
     ∷ (FromJSON (α → α), ToJSON α)
     ⇒ ProgramInfoValidate α []
@@ -131,20 +299,31 @@ runTest
         -- ^ test assertions
     → IO Bool
 runTest mInfo label succeed assertions = do
+
+    debug ∘ T.putStrLn $ "\nDEBUG: ======> " ⊕ label
+
+    debug ∘ T.putStrLn $ "DEBUG: runWithPkgInfoConfiguration"
     a ← run $ runWithPkgInfoConfiguration mInfo pkgInfo
+
+    debug ∘ T.putStrLn $ "DEBUG: runWithConfiguration"
     b ← run $ runWithConfiguration mInfo
+
     if a ≡ b && succeed ≡ (a && b)
       then
         return True
       else do
-        T.putStrLn $ "test " ⊕ label ⊕ " failed"
+        T.putStrLn $ "WARNING: test " ⊕ label ⊕ " failed"
         return False
   where
     run f = do
         ref ← newIORef False
-        handle (\(_ ∷ SomeException) → writeIORef ref False) $ withArgs args ∘ f $ \conf →
-            writeIORef ref $ check conf assertions
+        handle (handler ref) $ withArgs args ∘ f $ \conf →
+            writeIORef ref =<< check conf assertions
         readIORef ref
 
     args = concatMap (\(ConfAssertion x _ _) → x) assertions
+
+    handler ref (e ∷ SomeException) = do
+        writeIORef ref False
+        debug ∘ T.putStrLn $ "DEBUG: caugth exception: " ⊕ sshow e
 


### PR DESCRIPTION
* [x] improve test code
* [x] support static configuration file locations
* [x] tests for parsing of configuration files
* [x] loading of remote configuration files from static URLs
* [x] loading of remote configuration files form `--config-file` flags
* [x] distinguish between `required` and `optional` configuration files (for static file locations)
* [x] support for more than a single `--config-file` option
* [x] include precedence logic and configuration file loading into help message
* [x] documentation of logic for configuration file precedences