### PR TITLE
Monoid updates

### DIFF
--- a/configuration-tools.cabal
+++ b/configuration-tools.cabal
@@ -123,6 +123,7 @@ Test-Suite url-example-test
         errors >= 1.4.3,
         mtl >= 2.2,
         text >= 1.0,
+        unordered-containers >= 0.2.4.0,
         yaml >= 0.8.8.3
 
     if flag(remote-configs)

--- a/configuration-tools.cabal
+++ b/configuration-tools.cabal
@@ -112,6 +112,7 @@ Test-Suite url-example-test
 
     other-modules:
         Example
+        TestTools
 
     build-depends:
         base >= 4.6 && < 5.0,

--- a/src/Configuration/Utils/Internal.hs
+++ b/src/Configuration/Utils/Internal.hs
@@ -18,6 +18,7 @@ module Configuration.Utils.Internal
 , Lens'
 , Lens
 , Iso'
+, Iso
 , iso
 
 -- * Misc Utils
@@ -81,9 +82,10 @@ view l = asks (getConst #. l Const)
 -- In case it is already import from the lens package this should be hidden
 -- from the import.
 --
-type Iso' β α = (Profunctor π, Functor φ) ⇒ π α (φ α) → π β (φ β)
+type Iso σ τ α β = (Profunctor π, Functor φ) ⇒ π α (φ β) → π σ (φ τ)
+type Iso' σ α = Iso σ σ α α
 
-iso ∷ (β → α) → (α → β) → Iso' β α
+iso ∷ (σ → α) → (β → τ) → Iso σ τ α β
 iso f g = dimap f (fmap g)
 {-# INLINE iso #-}
 

--- a/test/TestExample.hs
+++ b/test/TestExample.hs
@@ -1,9 +1,11 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE UnicodeSyntax #-}
 
@@ -22,11 +24,14 @@ import TestTools
 
 import Configuration.Utils
 import Configuration.Utils.Internal
+import Configuration.Utils.Validation
 
 import Control.Monad
 
+import qualified Data.HashMap.Strict as HM
 import qualified Data.List as L
 import Data.Monoid.Unicode
+import Data.String
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 
@@ -58,7 +63,13 @@ main =
             ⊕ tests2Files3 "remote-" (serverUrl ⊕ "/config0") (serverUrl ⊕ "/config1")
             ⊕ testsInvalidUrl
 #endif
+            ⊕ routingTableTests
+            ⊕ textAppendTestsR
+            ⊕ textAppendTestsFilesR
+            ⊕ textAppendTestsL
+            ⊕ textAppendTestsFilesL
             ⊕ testPrintHelp [tmpPath0, tmpPath1]
+
 
         T.putStrLn $ "success: " ⊕ sshow (length successes)
         T.putStrLn $ "failures: " ⊕ sshow (length failures)
@@ -320,3 +331,210 @@ t3 = ConfAssertion ["--user=c_u"] (auth ∘ user) "c_u"
 t4 ∷ ConfAssertion HttpURL
 t4 = ConfAssertion ["--pwd=c_pwd"] (auth ∘ pwd) "c_pwd"
 
+-- -------------------------------------------------------------------------- --
+-- Test Monoid Updates
+
+-- HashMap
+--
+newtype RoutingTable = RoutingTable { _routingTableMap ∷ HM.HashMap T.Text T.Text }
+
+routingTableMap ∷ Lens' RoutingTable (HM.HashMap T.Text T.Text)
+routingTableMap = lens _routingTableMap $ \a b → a { _routingTableMap = b }
+
+defaultRoutingTable ∷ RoutingTable
+defaultRoutingTable = RoutingTable HM.empty
+
+instance ToJSON RoutingTable where
+    toJSON RoutingTable{..} = object
+        [ "route_map" .= _routingTableMap
+        ]
+
+instance FromJSON (RoutingTable → RoutingTable) where
+    parseJSON = withObject "RoutingTable" $ \o → id
+        <$< routingTableMap . fromLeftMonoidalUpdate %.: "route_map" × o
+
+pRoutingTable ∷ MParser RoutingTable
+pRoutingTable = routingTableMap %:: pLeftMonoidalUpdate pRoute
+  where
+    pRoute = option (eitherReader readRoute)
+        × long "route"
+        ⊕ help "add a route to the routing table; the APIROUTE part must not contain a colon character"
+        ⊕ metavar "APIROUTE:APIURL"
+
+    readRoute s = case break (== ':') s of
+        (a,':':b) → fmapL T.unpack $ do
+            validateNonEmpty "APIROUTE" a
+            validateHttpOrHttpsUrl "APIURL" b
+            return $ HM.singleton (T.pack a) (T.pack b)
+        _ → Left "missing colon between APIROUTE and APIURL"
+
+    fmapL f = either (Left . f) Right
+
+mainInfoRoutingTable ∷ ProgramInfoValidate RoutingTable []
+mainInfoRoutingTable = programInfoValidate "Routing Table" pRoutingTable defaultRoutingTable (const $ return ())
+
+routingTableTests ∷ [IO Bool]
+routingTableTests =
+    [ run 0 [ConfAssertion ["--route=a:" ⊕ b0] (routingTableMap ∘ at "a") $ Just b0]
+    , run 1 [ConfAssertion ["--route=a:" ⊕ b0, "--route=a:" ⊕ b1] (routingTableMap ∘ at "a") $ Just b1]
+    , run 2 [ConfAssertion ["--route=a:" ⊕ b0, "--route=a:" ⊕ b1] (routingTableMap ∘ at "a") $ Just b1]
+    , run 3 [ConfAssertion ["--route=a:" ⊕ b0, "--route=b:" ⊕ b1] (routingTableMap ∘ at "a") $ Just b0]
+    , run 4 [ConfAssertion ["--route=a:" ⊕ b0, "--route=b:" ⊕ b1] (routingTableMap ∘ at "b") $ Just b1]
+    , run 5 [ConfAssertion ["--route=a:" ⊕ b0, "--route=b:" ⊕ b1] (routingTableMap ∘ at "c") Nothing]
+    ]
+  where
+    b0,b1 ∷ IsString a ⇒ a
+    b0 = "http://b0"
+    b1 = "https://b1"
+    run (x ∷ Int) = runTest pkgInfo mainInfoRoutingTable ("routing-table-" ⊕ sshow x) True
+
+    at k f m = f mv <&> \r -> case r of
+        Nothing -> maybe m (const (HM.delete k m)) mv
+        Just v' -> HM.insert k v' m
+      where
+        mv = HM.lookup k m
+        (<&>) = flip fmap
+
+-- Text with right append
+--
+newtype StringConfigR = StringConfigR { _stringConfigR ∷ T.Text }
+
+stringConfigR ∷ Lens' StringConfigR T.Text
+stringConfigR = lens _stringConfigR $ \a b → a { _stringConfigR = b }
+
+defaultStringConfigR ∷ StringConfigR
+defaultStringConfigR = StringConfigR "|"
+
+instance ToJSON StringConfigR where
+    toJSON StringConfigR{..} = object
+        [ "string" .= _stringConfigR
+        ]
+
+instance FromJSON (StringConfigR → StringConfigR) where
+    parseJSON = withObject "StringConfigR" $ \o → id
+        <$< stringConfigR . fromRightMonoidalUpdate %.: "string" × o
+
+pStringConfigR ∷ MParser StringConfigR
+pStringConfigR = stringConfigR %:: pRightMonoidalUpdate pString
+  where
+    pString = T.pack <$> strOption × long "string"
+
+textAppendTestsR ∷ [IO Bool]
+textAppendTestsR =
+    [ run 0 True [ConfAssertion [] stringConfigR "|"]
+    , run 1 True [ConfAssertion ["--string=a"] stringConfigR "|a"]
+
+    , run 2 True [ConfAssertion ["--string=a", "--string=b"] stringConfigR "|ab"]
+    , run 3 False [ConfAssertion ["--string=a", "--string=b"] stringConfigR "|ba"]
+    , run 4 False [ConfAssertion ["--string=b", "--string=a"] stringConfigR "|ab"]
+    , run 5 True [ConfAssertion ["--string=b", "--string=a"] stringConfigR "|ba"]
+
+    , run 6 False [ConfAssertion ["--string=aaa", "--string=bbb"] stringConfigR "|bbbaaa"]
+    , run 7 True [ConfAssertion ["--string=aaa", "--string=bbb"] stringConfigR "|aaabbb"]
+    , run 8 True [ConfAssertion ["--string=bbb", "--string=aaa"] stringConfigR "|bbbaaa"]
+    , run 9 False [ConfAssertion ["--string=bbb", "--string=aaa"] stringConfigR "|aaabbb"]
+    ]
+  where
+    run (x ∷ Int) = runTest pkgInfo mi ("stringR-" ⊕ sshow x)
+    mi = programInfoValidate "Routing Table" pStringConfigR defaultStringConfigR (const $ return ())
+
+textAppendTestsFilesR ∷ [IO Bool]
+textAppendTestsFilesR =
+    [ run ca 0 True [ConfAssertion [] stringConfigR "|a"]
+
+    , run ca 2 True [ConfAssertion ["--string=b"] stringConfigR "|ab"]
+    , run ca 3 False [ConfAssertion ["--string=b"] stringConfigR "|ba"]
+    , run cb 4 False [ConfAssertion ["--string=a"] stringConfigR "|ab"]
+    , run cb 5 True [ConfAssertion ["--string=a"] stringConfigR "|ba"]
+
+    , run2 ca ca 6 True [ConfAssertion [] stringConfigR "|aa"]
+    , run2 ca cb 6 False [ConfAssertion [] stringConfigR "|ba"]
+    , run2 ca cb 7 True [ConfAssertion [] stringConfigR "|ab"]
+    , run2 cb ca 8 True [ConfAssertion [] stringConfigR "|ba"]
+    , run2 cb ca 9 False [ConfAssertion [] stringConfigR "|ab"]
+    ]
+  where
+    ca = StringConfigR "a"
+    cb = StringConfigR "b"
+    run c (x ∷ Int) b a = withConfigFile c $ \file →
+        runTest pkgInfo (mi [file]) ("stringL-file1-" ⊕ sshow x) b a
+
+    run2 c0 c1 (x ∷ Int) b a =
+        withConfigFile c0 $ \file0 →
+        withConfigFile c1 $ \file1 →
+        runTest pkgInfo (mi [file0,file1]) ("stringL-file2-" ⊕ sshow x) b a
+
+    mi files = set piConfigurationFiles (map ConfigFileRequired files) $
+      programInfoValidate "Routing Table" pStringConfigR defaultStringConfigR (const $ return ())
+
+-- Text with left append
+--
+newtype StringConfigL = StringConfigL { _stringConfigL ∷ T.Text }
+
+stringConfigL ∷ Lens' StringConfigL T.Text
+stringConfigL = lens _stringConfigL $ \a b → a { _stringConfigL = b }
+
+defaultStringConfigL ∷ StringConfigL
+defaultStringConfigL = StringConfigL "|"
+
+instance ToJSON StringConfigL where
+    toJSON StringConfigL{..} = object
+        [ "string" .= _stringConfigL
+        ]
+
+instance FromJSON (StringConfigL → StringConfigL) where
+    parseJSON = withObject "StringConfigL" $ \o → id
+        <$< stringConfigL . fromLeftMonoidalUpdate %.: "string" × o
+
+pStringConfigL ∷ MParser StringConfigL
+pStringConfigL = stringConfigL %:: pLeftMonoidalUpdate pString
+  where
+    pString = T.pack <$> strOption × long "string"
+
+textAppendTestsL ∷ [IO Bool]
+textAppendTestsL =
+    [ run 0 True [ConfAssertion [] stringConfigL "|"]
+    , run 1 True [ConfAssertion ["--string=a"] stringConfigL "a|"]
+
+    , run 2 True [ConfAssertion ["--string=a", "--string=b"] stringConfigL "ba|"]
+    , run 3 False [ConfAssertion ["--string=a", "--string=b"] stringConfigL "ab|"]
+    , run 4 False [ConfAssertion ["--string=b", "--string=a"] stringConfigL "ba|"]
+    , run 5 True [ConfAssertion ["--string=b", "--string=a"] stringConfigL "ab|"]
+
+    , run 6 True [ConfAssertion ["--string=aaa", "--string=bbb"] stringConfigL "bbbaaa|"]
+    , run 7 False [ConfAssertion ["--string=aaa", "--string=bbb"] stringConfigL "aaabbb|"]
+    , run 8 False [ConfAssertion ["--string=bbb", "--string=aaa"] stringConfigL "bbbaaa|"]
+    , run 9 True [ConfAssertion ["--string=bbb", "--string=aaa"] stringConfigL "aaabbb|"]
+    ]
+  where
+    run (x ∷ Int) = runTest pkgInfo mi ("stringL-" ⊕ sshow x)
+    mi = programInfoValidate "Routing Table" pStringConfigL defaultStringConfigL (const $ return ())
+
+textAppendTestsFilesL ∷ [IO Bool]
+textAppendTestsFilesL =
+    [ run ca 1 True [ConfAssertion [] stringConfigL "a|"]
+
+    , run ca 2 True [ConfAssertion ["--string=b"] stringConfigL "ba|"]
+    , run ca 3 False [ConfAssertion ["--string=b"] stringConfigL "ab|"]
+    , run cb 4 False [ConfAssertion ["--string=a"] stringConfigL "ba|"]
+    , run cb 5 True [ConfAssertion ["--string=a"] stringConfigL "ab|"]
+
+    , run2 ca ca 1 True [ConfAssertion [] stringConfigL "aa|"]
+    , run2 ca cb 2 True [ConfAssertion [] stringConfigL "ba|"]
+    , run2 ca cb 3 False [ConfAssertion [] stringConfigL "ab|"]
+    , run2 cb ca 4 False [ConfAssertion [] stringConfigL "ba|"]
+    , run2 cb ca 5 True [ConfAssertion [] stringConfigL "ab|"]
+    ]
+  where
+    ca = StringConfigL "a"
+    cb = StringConfigL "b"
+    run c (x ∷ Int) b a = withConfigFile c $ \file →
+        runTest pkgInfo (mi [file]) ("stringL-file1-" ⊕ sshow x) b a
+
+    run2 c0 c1 (x ∷ Int) b a =
+        withConfigFile c0 $ \file0 →
+        withConfigFile c1 $ \file1 →
+        runTest pkgInfo (mi [file0,file1]) ("stringL-file2-" ⊕ sshow x) b a
+
+    mi files = set piConfigurationFiles (map ConfigFileRequired files) $
+      programInfoValidate "Routing Table" pStringConfigL defaultStringConfigL (const $ return ())

--- a/test/TestTools.hs
+++ b/test/TestTools.hs
@@ -1,0 +1,235 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NoMonomorphismRestriction #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE UnicodeSyntax #-}
+
+-- |
+-- Module: TestTools
+-- Copyright: Copyright © 2015 PivotCloud, Inc.
+-- License: MIT
+-- Maintainer: Lars Kuhtz <lkuhtz@pivotmail.com>
+-- Stability: experimental
+--
+-- TODO
+--
+module TestTools
+(
+-- * Very Simple Debugging
+  enableDebug
+, debug
+
+-- * Configuration Assertions for Testing
+, ConfAssertion(..)
+, trueLens
+, trueAssertion
+
+-- * Test Execution
+, check
+, runTest
+
+-- * Test Config Files
+, withConfigFile
+, withConfigFileText
+#ifdef REMOTE_CONFIGS
+, ConfigType(..)
+, serverUrl
+, withConfigFileServer
+#endif
+) where
+
+import Configuration.Utils
+import Configuration.Utils.Internal
+
+import Control.Exception
+import Control.Monad
+
+import qualified Data.ByteString.Char8 as B8
+import Data.IORef
+import Data.Maybe
+import Data.Monoid.Unicode
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
+import qualified Data.Yaml as Yaml
+
+import Distribution.Simple.Utils (withTempFile)
+
+import Prelude.Unicode
+
+import System.Environment
+import System.IO
+
+#ifdef REMOTE_CONFIGS
+import Control.Concurrent
+import qualified Data.ByteString.Lazy as LB
+import qualified Data.Text.Encoding as T
+import qualified Network.Wai as WAI
+import qualified Network.Wai.Handler.Warp as WARP
+import qualified Network.HTTP.Types as HTTP
+#endif
+
+-- -------------------------------------------------------------------------- --
+-- Very Simple Debugging
+
+enableDebug ∷ Bool
+enableDebug = False
+
+debug
+    ∷ Monad m
+    ⇒ m ()
+    → m ()
+debug a
+    | enableDebug = a
+    | otherwise = return ()
+
+-- -------------------------------------------------------------------------- --
+-- Configuration Assertions for Testing
+
+-- | Specify a assertion about the parsed configuration
+--
+-- The parameters are
+--
+-- 1. list of command line arguments,
+-- 2. lens for the configuration value
+-- 3. the expected value
+--
+data ConfAssertion β = ∀ α . Eq α ⇒ ConfAssertion [String] (Lens' β α) α
+
+trueLens ∷ Lens' β ()
+trueLens = lens (const ()) const
+
+trueAssertion ∷ [String] → ConfAssertion β
+trueAssertion args = ConfAssertion args trueLens ()
+
+-- -------------------------------------------------------------------------- --
+-- Test execution
+
+-- Check the given list of assertions for the given configuration value
+--
+check
+    ∷ α
+    → [ConfAssertion α]
+    → IO Bool
+check conf assertions =
+    foldM (\a (b,n) → (&& a) <$> go b n) True $ zip assertions [0 ∷ Int ..]
+  where
+    go (ConfAssertion _ l v) n =
+        if view l conf ≡ v
+          then do
+            debug ∘ T.putStrLn $ "DEBUG: assertion " ⊕ sshow n ⊕ " succeeded"
+            return True
+          else do
+            debug ∘ T.putStrLn $ "DEBUG: assertion " ⊕ sshow n ⊕ " failed"
+            return False
+
+-- | Run a test with an expected outcome ('True' or 'False')
+-- for a given that of assertions.
+--
+runTest
+    ∷ (FromJSON (α → α), ToJSON α)
+    ⇒ PkgInfo
+    → ProgramInfoValidate α []
+    → T.Text
+        -- ^ label for the test case
+    → Bool
+        -- ^ expected outcome
+    → [ConfAssertion α]
+        -- ^ test assertions
+    → IO Bool
+runTest pkgInfo mInfo label succeed assertions = do
+
+    debug ∘ T.putStrLn $ "\nDEBUG: ======> " ⊕ label
+
+    debug ∘ T.putStrLn $ "DEBUG: runWithPkgInfoConfiguration"
+    a ← run $ runWithPkgInfoConfiguration mInfo pkgInfo
+
+    debug ∘ T.putStrLn $ "DEBUG: runWithConfiguration"
+    b ← run $ runWithConfiguration mInfo
+
+    if a ≡ b && succeed ≡ (a && b)
+      then
+        return True
+      else do
+        T.putStrLn $ "WARNING: test " ⊕ label ⊕ " failed"
+        return False
+  where
+    run f = do
+        ref ← newIORef False
+        handle (handler ref) $ withArgs args ∘ f $ \conf →
+            writeIORef ref =<< check conf assertions
+        readIORef ref
+
+    args = concatMap (\(ConfAssertion x _ _) → x) assertions
+
+    handler ref (e ∷ SomeException) = do
+        writeIORef ref False
+        debug ∘ T.putStrLn $ "DEBUG: caugth exception: " ⊕ sshow e
+
+-- -------------------------------------------------------------------------- --
+-- Test Config Files
+--
+
+withConfigFile
+    ∷ ToJSON γ
+    ⇒ γ
+    → (T.Text → IO α)
+    → IO α
+withConfigFile config inner =
+    withTempFile "." "tmp_TestExample.yml" $ \tmpPath tmpHandle → do
+        B8.hPutStrLn tmpHandle ∘ Yaml.encode $ config
+        hClose tmpHandle
+        inner $ T.pack tmpPath
+
+withConfigFileText
+    ∷ T.Text
+    → (T.Text → IO α)
+    → IO α
+withConfigFileText configText inner =
+    withTempFile "." "tmp_TestExample.yml" $ \tmpPath tmpHandle → do
+        T.hPutStrLn tmpHandle configText
+        hClose tmpHandle
+        inner $ T.pack tmpPath
+
+
+#ifdef REMOTE_CONFIGS
+data ConfigType = ∀ γ . ToJSON γ ⇒ ConfigType γ
+
+instance ToJSON ConfigType where
+    toJSON (ConfigType a) = toJSON a
+
+withConfigFileServer
+    ∷ [(T.Text, ConfigType)]
+    → [(T.Text, T.Text)]
+    → IO α
+    → IO α
+withConfigFileServer configs configTexts inner = do
+    void ∘ forkIO $ server serverPort configs configTexts
+    inner
+
+serverPort ∷ Int
+serverPort = 8283
+
+serverUrl ∷ T.Text
+serverUrl = "http://127.0.0.1:" ⊕ sshow serverPort
+
+server
+    ∷ Int
+    → [(T.Text, ConfigType)]
+    → [(T.Text, T.Text)]
+    → IO ()
+server port configs configTexts = WARP.run port $ \req respond → do
+    let maybeBody = LB.fromStrict <$> do
+            p ← listToMaybe $ WAI.pathInfo req
+            do
+                Yaml.encode <$> lookup p configs
+                <|>
+                (T.encodeUtf8 <$> lookup p configTexts)
+
+    respond $ case maybeBody of
+        Just body → WAI.responseLBS HTTP.status200 [] body
+        Nothing → WAI.responseLBS HTTP.status404 [] "resource not found"
+#endif


### PR DESCRIPTION
Tools for defining configurations for types with an `Monoid` instance.

* [x] `newtype`, `instance`, and `lens` for conveniently defining `FromJSON` update for types with a 
      `Monoid` instance.

* [x] a function for defining command line parsers for types with a `Monoid` instance

* [x] support for monoids that have right precedence and those with left precedence (this is of relevance
       for monoids that are order sensitive, like `List`, but also for monoids with set semantics with 
       non-extensional equality such as `HashMap`).

* [x] test cases. This is postponed until #23 is merged, which greatly improves support for writing test instances.