### PR TITLE
Drop dependency on errors. It wasn't used in the code any more.

### DIFF
--- a/configuration-tools.cabal
+++ b/configuration-tools.cabal
@@ -107,7 +107,6 @@ Library
         deepseq >= 1.3,
         directory >= 1.2.1.0,
         dlist >= 0.7.1,
-        errors >= 1.4.3,
         filepath >= 1.3.0.1,
         network-uri >= 2.6.0.1,
         optparse-applicative >= 0.10,
@@ -173,7 +172,6 @@ Test-Suite url-example-test
         bytestring >= 0.10,
         Cabal >= 1.18,
         configuration-tools,
-        errors >= 1.4.3,
         text >= 1.0,
         unordered-containers >= 0.2.4.0,
         yaml >= 0.8.8.3


### PR DESCRIPTION
This addresses Issue #42